### PR TITLE
PI-10682: Fix DebugSwift data race error for Xcode 26.4

### DIFF
--- a/.claude/skills/upstream-sync/SKILL.md
+++ b/.claude/skills/upstream-sync/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: upstream-sync
+description: 'Sync this repo with upstream DebugSwift/DebugSwift while preserving Prex customizations. Use when: (1) the user says "sync with upstream", "update from DebugSwift", or "check upstream", (2) fixing build errors that upstream has already resolved, (3) comparing local files with upstream versions, (4) pulling in new features from upstream DebugSwift.'
+disable-model-invocation: true
+argument-hint: '[file-or-feature-to-sync]'
+---
+
+# Upstream Sync
+
+Sync this fork of DebugSwift/DebugSwift with the upstream repo while preserving Prex-specific customizations.
+
+## Workflow Decision Tree
+
+### 1) Sync a specific file
+- Use `mcp__prex-mcp-server__code_read` to read the upstream version from `DebugSwift/DebugSwift` repo (branch: `main`)
+- Read the local version with the Read tool
+- Diff the two and apply upstream changes, skipping any Prex custom sections
+
+### 2) Check for upstream fixes to a build error
+- Identify the file(s) with errors locally
+- Read the upstream version of those files using MCP tools
+- Compare the relevant methods/sections to find the fix
+- Apply the fix pattern while keeping local customizations
+
+### 3) Full sync audit
+- Use `mcp__prex-mcp-server__code_tree` to get the upstream directory structure
+- Compare with local structure using Glob
+- Identify new files in upstream that are missing locally
+- Identify files that have diverged
+- Report findings before making changes
+
+### 4) Add a new upstream feature
+- Read the upstream files for that feature using MCP tools
+- Add the new files to the local repo
+- Wire them into existing code as needed
+
+## Prex Custom Code (never overwrite)
+
+These files contain Prex-specific modifications — preserve them during any sync:
+- `DebugSwift/Resources/PrivacyInfo.xcprivacy` — Privacy manifest
+- `DebugSwift/Sources/Base/TabBarController.swift` — DDD2 device touch area fix
+- `DebugSwift/Sources/Settings/DebugSwift.swift` — Instance method API with method chaining
+- `DebugSwift/Sources/Helpers/Tools/UserDefaultsAccess.swift` — Debugger toggle support
+- `Package.swift` — iOS 14+ platform target (upstream uses iOS 13+)
+
+## MCP Tools for Reading Upstream
+
+- `mcp__prex-mcp-server__code_tree` — get directory structure of upstream repo
+- `mcp__prex-mcp-server__code_read` — read a specific file from upstream
+- `mcp__prex-mcp-server__code_grep` — search upstream code for patterns
+- `mcp__prex-mcp-server__code_search` — semantic search in upstream repo
+
+Always specify repo as `DebugSwift/DebugSwift` and branch as `main` when using these tools.
+
+## Rules
+
+- Always read both local and upstream versions before making changes
+- Create a feature branch for sync changes
+- If a file is in the Prex custom list above, merge carefully — apply only non-conflicting upstream changes
+- If upstream introduces new dependencies or platform changes, flag to the developer before applying
+- Never run xcodebuild — ask the developer to verify the build in Xcode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# prex-ios-alien-debug-swift
+
+Fork of [DebugSwift/DebugSwift](https://github.com/DebugSwift/DebugSwift) with Prex-specific customizations.
+
+## Stack
+- Swift 6 strict concurrency mode (`swiftLanguageModes: [.v6]`)
+- iOS 14+ (upstream uses iOS 13+)
+- Swift Package Manager, no external dependencies
+
+## Prex Custom Code (preserve when syncing with upstream)
+- `DebugSwift/Resources/PrivacyInfo.xcprivacy` — Privacy manifest
+- `DebugSwift/Sources/Base/TabBarController.swift` — DDD2 device touch area fix
+- `DebugSwift/Sources/Settings/DebugSwift.swift` — Instance method API with method chaining
+- `DebugSwift/Sources/Helpers/Tools/UserDefaultsAccess.swift` — Debugger toggle support
+- `Package.swift` — iOS 14+ platform target
+
+## Upstream Sync
+- Upstream: https://github.com/DebugSwift/DebugSwift (branch: `main`)
+- Use MCP tools (`mcp__prex-mcp-server__code_*`) to read upstream code
+- When syncing: apply upstream fixes to shared code, never overwrite Prex customizations listed above
+
+## Relevant Skills
+- `/upstream-sync` — sync files with upstream DebugSwift/DebugSwift (local skill)
+- `/swift6-migration` — Swift 6 concurrency patterns (from prex-ios)
+- `/git-workflow` — branch, PR, commit, cherry-pick workflows (from prex-ios)
+- `/coding-standards` — Swift formatting conventions (from prex-ios)
+
+## Testing
+- Do NOT run `xcodebuild` — ask the developer to test in Xcode instead
+- Tests are in `Example/ExampleTests/Tests/`

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -69,6 +69,22 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
 
     private var threadOperator: ThreadOperator?
 
+    private struct NetworkReportData: @unchecked Sendable {
+        let url: URL?
+        let method: String?
+        let requestBody: Data?
+        let requestBodyStream: Data?
+        let requestHeaderFields: [String: String]?
+        let cachePolicy: UInt
+        let requestId: String
+        let responseMimeType: String?
+        let responseStatusCode: Int?
+        let responseHeaderFields: [AnyHashable: Any]?
+        let data: Data
+        let startTime: Date
+        let error: (any Error)?
+    }
+
     private func use(_ cache: CachedURLResponse) {
         DebugSwift.Network.shared.delegate?.urlSession(
             self,
@@ -163,62 +179,79 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             dataTask = nil
         }
 
-        Task { @Sendable in
-            guard await NetworkHelper.shared.isNetworkEnable else {
-                return
-            }
-            
-            await processNetworkData()
+        session?.invalidateAndCancel()
+        session = nil
+
+        let reportData = NetworkReportData(
+            url: request.url,
+            method: request.httpMethod,
+            requestBody: request.httpBody,
+            requestBodyStream: request.httpBodyStream?.toData(),
+            requestHeaderFields: request.allHTTPHeaderFields,
+            cachePolicy: request.cachePolicy.rawValue,
+            requestId: request.requestId,
+            responseMimeType: response?.mimeType,
+            responseStatusCode: response?.statusCode,
+            responseHeaderFields: response?.allHeaderFields,
+            data: data,
+            startTime: startTime,
+            error: error)
+
+        Task { @MainActor in
+            guard NetworkHelper.shared.isNetworkEnable
+            else { return }
+            Self.report(reportData)
         }
     }
     
     @MainActor
-    private func processNetworkData() async {
+    private static func report(_ reportData: NetworkReportData) {
         var model = HttpModel()
-        model.url = request.url
-        model.method = request.httpMethod
-        model.mineType = response?.mimeType
+        model.url = reportData.url
+        model.method = reportData.method
+        model.mineType = reportData.responseMimeType
 
-        if let requestBody = request.httpBody {
+        if let requestBody = reportData.requestBody {
             model.requestData = requestBody
         }
 
-        if let requestBodyStream = request.httpBodyStream {
-            model.requestData = requestBodyStream.toData()
+        if let requestBodyStream = reportData.requestBodyStream {
+            model.requestData = requestBodyStream
         }
 
-        if let httpResponse = response {
-            model.statusCode = "\(httpResponse.statusCode)"
+        if let statusCode = reportData.responseStatusCode {
+            model.statusCode = "\(statusCode)"
         }
 
-        model.responseData = data
-        model.size = data.formattedSize()
-        model.isImage = (response?.mimeType?.contains("image")) ?? false
+        model.responseData = reportData.data
+        model.size = reportData.data.formattedSize()
+        model.isImage = (reportData.responseMimeType?.contains("image")) ?? false
 
-        // Time
-        let startTimeDouble = startTime.timeIntervalSince1970
+        let startTimeDouble = reportData.startTime.timeIntervalSince1970
         let endTimeDouble = Date().timeIntervalSince1970
         let durationDouble = abs(endTimeDouble - startTimeDouble)
         let formattedDuration = String(format: "%.4f", durationDouble)
 
-        model.startTime = "\(startTime.formatted())"
+        model.startTime = "\(reportData.startTime.formatted())"
         model.endTime = "\(Date().formatted())"
         model.totalDuration = "\(formattedDuration) (s)"
 
-        model.errorDescription = error?.localizedDescription ?? ""
-        model.errorLocalizedDescription = error?.localizedDescription ?? ""
-        model.requestHeaderFields = request.allHTTPHeaderFields
+        model.errorDescription = reportData.error?.localizedDescription ?? ""
+        model.errorLocalizedDescription = reportData.error?.localizedDescription ?? ""
+        model.requestHeaderFields = reportData.requestHeaderFields
 
-        if let response {
-            model.responseHeaderFields = response.allHeaderFields.convertKeysToString()
-            model.responseHeaderFields?.updateValue(getCachePolicy(value: request.cachePolicy.rawValue), forKey: "Cache-Policy")
+        if let responseHeaderFields = reportData.responseHeaderFields {
+            model.responseHeaderFields = responseHeaderFields.convertKeysToString()
+            model.responseHeaderFields?.updateValue(
+                getCachePolicyString(value: reportData.cachePolicy),
+                forKey: "Cache-Policy")
         }
 
         if let responseDate = model.endTime {
             model.responseHeaderFields?.updateValue(responseDate, forKey: "Response-Date")
         }
 
-        if response?.mimeType == nil {
+        if reportData.responseMimeType == nil {
             model.isImage = false
         }
 
@@ -236,13 +269,12 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             }
         }
 
-        model.requestId = request.requestId
-        model = ErrorHelper.handle(error, model: model)
+        model.requestId = reportData.requestId
+        model = ErrorHelper.handle(reportData.error, model: model)
         if HttpDatasource.shared.addHttpRequest(model) {
             NotificationCenter.default.post(
                 name: NSNotification.Name("reloadHttp_DebugSwift"),
-                object: model.isSuccess
-            )
+                object: model.isSuccess)
         }
     }
 }
@@ -326,7 +358,7 @@ extension CustomHTTPProtocol: URLSessionDataDelegate {
         return true
     }
 
-    private func getCachePolicy(value: UInt?) -> String {
+    private static func getCachePolicyString(value: UInt?) -> String {
         switch value {
         case 0:
             return "useProtocolCachePolicy"

--- a/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
+++ b/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift
@@ -69,22 +69,6 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
 
     private var threadOperator: ThreadOperator?
 
-    private struct NetworkReportData: @unchecked Sendable {
-        let url: URL?
-        let method: String?
-        let requestBody: Data?
-        let requestBodyStream: Data?
-        let requestHeaderFields: [String: String]?
-        let cachePolicy: UInt
-        let requestId: String
-        let responseMimeType: String?
-        let responseStatusCode: Int?
-        let responseHeaderFields: [AnyHashable: Any]?
-        let data: Data
-        let startTime: Date
-        let error: (any Error)?
-    }
-
     private func use(_ cache: CachedURLResponse) {
         DebugSwift.Network.shared.delegate?.urlSession(
             self,
@@ -179,79 +163,84 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             dataTask = nil
         }
 
+        // Invalidate session to break retain cycle
         session?.invalidateAndCancel()
         session = nil
 
-        let reportData = NetworkReportData(
-            url: request.url,
-            method: request.httpMethod,
-            requestBody: request.httpBody,
-            requestBodyStream: request.httpBodyStream?.toData(),
-            requestHeaderFields: request.allHTTPHeaderFields,
-            cachePolicy: request.cachePolicy.rawValue,
-            requestId: request.requestId,
-            responseMimeType: response?.mimeType,
-            responseStatusCode: response?.statusCode,
-            responseHeaderFields: response?.allHeaderFields,
-            data: data,
-            startTime: startTime,
-            error: error)
+        let url = request.url
+        let method = request.httpMethod
+        let requestData = request.httpBody ?? request.httpBodyStream?.toData()
+        let responseData = data
+        let statusCode = response.map { "\($0.statusCode)" }
+        let mineType = response?.mimeType
+        let capturedStartTime = startTime
+        let capturedError = error
+        let requestHeaderFields = request.allHTTPHeaderFields
+        let responseHeaderFields = headersToString(response?.allHeaderFields)
+        let requestId = request.requestId
+        let cachePolicy = getCachePolicy(value: request.cachePolicy.rawValue)
 
         Task { @MainActor in
             guard NetworkHelper.shared.isNetworkEnable
             else { return }
+
+            let reportData = NetworkReportData(
+                url: url,
+                method: method,
+                requestData: requestData,
+                responseData: responseData,
+                statusCode: statusCode,
+                mineType: mineType,
+                startTime: capturedStartTime,
+                endTime: Date(),
+                error: capturedError,
+                requestHeaderFields: requestHeaderFields,
+                responseHeaderFields: responseHeaderFields,
+                requestId: requestId,
+                cachePolicy: cachePolicy)
             Self.report(reportData)
         }
     }
-    
+
     @MainActor
-    private static func report(_ reportData: NetworkReportData) {
+    private static func report(_ data: NetworkReportData) {
         var model = HttpModel()
-        model.url = reportData.url
-        model.method = reportData.method
-        model.mineType = reportData.responseMimeType
+        model.url = data.url
+        model.method = data.method
+        model.mineType = data.mineType
 
-        if let requestBody = reportData.requestBody {
-            model.requestData = requestBody
+        model.requestData = data.requestData
+
+        if let statusCode = data.statusCode {
+            model.statusCode = statusCode
         }
 
-        if let requestBodyStream = reportData.requestBodyStream {
-            model.requestData = requestBodyStream
-        }
+        model.responseData = data.responseData
+        model.size = data.responseData?.formattedSize()
+        model.isImage = (data.mineType?.contains("image")) ?? false
 
-        if let statusCode = reportData.responseStatusCode {
-            model.statusCode = "\(statusCode)"
-        }
-
-        model.responseData = reportData.data
-        model.size = reportData.data.formattedSize()
-        model.isImage = (reportData.responseMimeType?.contains("image")) ?? false
-
-        let startTimeDouble = reportData.startTime.timeIntervalSince1970
-        let endTimeDouble = Date().timeIntervalSince1970
+        // Time
+        let startTimeDouble = data.startTime.timeIntervalSince1970
+        let endTimeDouble = data.endTime.timeIntervalSince1970
         let durationDouble = abs(endTimeDouble - startTimeDouble)
         let formattedDuration = String(format: "%.4f", durationDouble)
 
-        model.startTime = "\(reportData.startTime.formatted())"
-        model.endTime = "\(Date().formatted())"
+        model.startTime = "\(data.startTime.formatted())"
+        model.endTime = "\(data.endTime.formatted())"
         model.totalDuration = "\(formattedDuration) (s)"
 
-        model.errorDescription = reportData.error?.localizedDescription ?? ""
-        model.errorLocalizedDescription = reportData.error?.localizedDescription ?? ""
-        model.requestHeaderFields = reportData.requestHeaderFields
+        model.errorDescription = data.error?.localizedDescription ?? ""
+        model.errorLocalizedDescription = data.error?.localizedDescription ?? ""
+        model.requestHeaderFields = data.requestHeaderFields
 
-        if let responseHeaderFields = reportData.responseHeaderFields {
-            model.responseHeaderFields = responseHeaderFields.convertKeysToString()
-            model.responseHeaderFields?.updateValue(
-                getCachePolicyString(value: reportData.cachePolicy),
-                forKey: "Cache-Policy")
-        }
+        model.responseHeaderFields = data.responseHeaderFields
+        model.responseHeaderFields?.updateValue(data.cachePolicy, forKey: "Cache-Policy")
 
         if let responseDate = model.endTime {
             model.responseHeaderFields?.updateValue(responseDate, forKey: "Response-Date")
         }
 
-        if reportData.responseMimeType == nil {
+        if data.mineType == nil {
             model.isImage = false
         }
 
@@ -269,13 +258,22 @@ public final class CustomHTTPProtocol: URLProtocol, @unchecked Sendable {
             }
         }
 
-        model.requestId = reportData.requestId
-        model = ErrorHelper.handle(reportData.error, model: model)
+        model.requestId = data.requestId
+        model = ErrorHelper.handle(data.error, model: model)
         if HttpDatasource.shared.addHttpRequest(model) {
             NotificationCenter.default.post(
                 name: NSNotification.Name("reloadHttp_DebugSwift"),
                 object: model.isSuccess)
         }
+    }
+
+    private func headersToString(_ headers: [AnyHashable: Any]?) -> [String: String]? {
+        guard let headers else { return nil }
+        var result = [String: String]()
+        for (key, value) in headers {
+            result["\(key)"] = "\(value)"
+        }
+        return result
     }
 }
 
@@ -358,7 +356,7 @@ extension CustomHTTPProtocol: URLSessionDataDelegate {
         return true
     }
 
-    private static func getCachePolicyString(value: UInt?) -> String {
+    private func getCachePolicy(value: UInt?) -> String {
         switch value {
         case 0:
             return "useProtocolCachePolicy"
@@ -427,5 +425,53 @@ extension CustomHTTPProtocol: URLSessionTaskDelegate {
                 totalBytesExpectedToSend: totalBytesExpectedToSend
             )
         }
+    }
+}
+
+// MARK: - Network Reporting Data
+
+struct NetworkReportData: Sendable {
+    let url: URL?
+    let method: String?
+    let requestData: Data?
+    let responseData: Data?
+    let statusCode: String?
+    let mineType: String?
+    let startTime: Date
+    let endTime: Date
+    let error: Error?
+    let requestHeaderFields: [String: String]?
+    let responseHeaderFields: [String: String]?
+    let requestId: String
+    let cachePolicy: String
+
+    init(
+        url: URL?,
+        method: String?,
+        requestData: Data?,
+        responseData: Data?,
+        statusCode: String?,
+        mineType: String?,
+        startTime: Date,
+        endTime: Date,
+        error: Error?,
+        requestHeaderFields: [String: String]?,
+        responseHeaderFields: [String: String]?,
+        requestId: String,
+        cachePolicy: String
+    ) {
+        self.url = url
+        self.method = method
+        self.requestData = requestData
+        self.responseData = responseData
+        self.statusCode = statusCode
+        self.mineType = mineType
+        self.startTime = startTime
+        self.endTime = endTime
+        self.error = error
+        self.requestHeaderFields = requestHeaderFields
+        self.responseHeaderFields = responseHeaderFields
+        self.requestId = requestId
+        self.cachePolicy = cachePolicy
     }
 }


### PR DESCRIPTION
## Summary
- Fix Swift 6 "Sending 'self' risks causing data races" error in `HTTPProtocol.stopLoading()` by capturing values into a `Sendable` struct before the `Task` boundary and using a static `report()` method — same pattern as upstream DebugSwift
- Add session invalidation in `stopLoading()` to break retain cycles
- Add `CLAUDE.md` and `/upstream-sync` skill for repo tooling
- Copy HTTPProtocol from https://github.com/DebugSwift/DebugSwift/blob/main/DebugSwift/Sources/Features/Network/Helpers/HTTPProtocol.swift

## JIRA
[PI-10682](https://prex.atlassian.net/browse/PI-10682)

[PI-10682]: https://prex.atlassian.net/browse/PI-10682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Relates to https://github.com/teamprex/prex-ios/pull/11773

https://github.com/user-attachments/assets/e47dbf46-09d2-49b2-9a98-fe364e34f143

